### PR TITLE
[ATR-63] 뉴스레터 get API 구현

### DIFF
--- a/src/main/java/run/attraction/api/v1/introduction/controller/IntroductionController.java
+++ b/src/main/java/run/attraction/api/v1/introduction/controller/IntroductionController.java
@@ -1,0 +1,28 @@
+package run.attraction.api.v1.introduction.controller;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import run.attraction.api.v1.introduction.dto.response.NewsletterResponse;
+import run.attraction.api.v1.introduction.service.IntroductionService;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/newsletters")
+@Validated
+public class IntroductionController {
+
+  private final IntroductionService introductionService;
+
+  @GetMapping("/{newsletterId}")
+  public ResponseEntity<?>  getNewsletter(@PathVariable("newsletterId") @NotNull @Min(1) Long newsletterId) {
+      NewsletterResponse newsletter = introductionService.getNewsletter(newsletterId);
+      return ResponseEntity.ok(newsletter);
+  }
+}

--- a/src/main/java/run/attraction/api/v1/introduction/dto/response/NewsletterResponse.java
+++ b/src/main/java/run/attraction/api/v1/introduction/dto/response/NewsletterResponse.java
@@ -1,0 +1,28 @@
+package run.attraction.api.v1.introduction.dto.response;
+
+import java.util.List;
+import run.attraction.api.v1.introduction.Category;
+import run.attraction.api.v1.introduction.Newsletter;
+import run.attraction.api.v1.introduction.UploadDays;
+
+public record NewsletterResponse(
+    String name,
+    String description,
+    List<UploadDays> uploadDays,
+    Category category,
+    String mainLink,
+    String subscribeLink,
+    String thumbnail
+) {
+  public NewsletterResponse(Newsletter newsletter) {
+    this(
+        newsletter.getName(),
+        newsletter.getDescription(),
+        newsletter.getUploadDays(),
+        newsletter.getCategory(),
+        newsletter.getMainLink(),
+        newsletter.getSubscriptionLink(),
+        newsletter.getThumbnail()
+    );
+  }
+}

--- a/src/main/java/run/attraction/api/v1/introduction/exception/ErrorMessages.java
+++ b/src/main/java/run/attraction/api/v1/introduction/exception/ErrorMessages.java
@@ -1,0 +1,14 @@
+package run.attraction.api.v1.introduction.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Getter
+public enum ErrorMessages {
+  INVALID_TYPE("올바른 타입으로 요청해주세요"),
+  SEVER_ERROR("서버 에러"),
+  NOT_EXIST_NEWSLETTER("존재하지 않는 뉴스레터입니다");
+
+  private final String viewName;
+}

--- a/src/main/java/run/attraction/api/v1/introduction/exception/GlobalExceptionHandler.java
+++ b/src/main/java/run/attraction/api/v1/introduction/exception/GlobalExceptionHandler.java
@@ -1,0 +1,24 @@
+package run.attraction.api.v1.introduction.exception;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+  @ExceptionHandler(Exception.class)
+  @ResponseStatus(HttpStatus.INTERNAL_SERVER_ERROR)
+  public ResponseEntity<Map<String, String>> handleGlobalException(Exception ex, WebRequest request) {
+    Map<String, String> errors = new HashMap<>();
+    String errorMessage = ex.getMessage().isEmpty() ? ErrorMessages.SEVER_ERROR.getViewName() : ex.getMessage();
+    errors.put("message", errorMessage);
+    errors.put("details", request.getDescription(false));
+    return new ResponseEntity<>(errors, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/src/main/java/run/attraction/api/v1/introduction/exception/IntroductionExceptionHandler.java
+++ b/src/main/java/run/attraction/api/v1/introduction/exception/IntroductionExceptionHandler.java
@@ -1,0 +1,52 @@
+package run.attraction.api.v1.introduction.exception;
+
+import jakarta.validation.ConstraintViolationException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+import run.attraction.api.v1.introduction.controller.IntroductionController;
+
+@Order(1)
+@RestControllerAdvice(assignableTypes = IntroductionController.class)
+public class IntroductionExceptionHandler {
+
+  private ResponseEntity<Map<String, String>> buildResponseEntity(String message, String details, HttpStatus status) {
+    Map<String,  String> errors = new HashMap<>();
+    errors.put("message", message);
+    errors.put("details", details);
+    return new ResponseEntity<>(errors, status);
+  }
+
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  public ResponseEntity<Map<String, String>> handleTypeMismatchException(MethodArgumentTypeMismatchException ex, WebRequest request) {
+    return buildResponseEntity(ErrorMessages.INVALID_TYPE.getViewName(), request.getDescription(false), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(NoSuchElementException.class)
+  public ResponseEntity<Map<String, String>> handleNoSuchElementException(Exception ex, WebRequest request) {
+    String errorMessage = ex.getMessage().isEmpty() ? ErrorMessages.SEVER_ERROR.getViewName() : ex.getMessage();
+    return buildResponseEntity(errorMessage, request.getDescription(false), HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(ConstraintViolationException.class)
+  public ResponseEntity<Map<String, String>> handleConstraintViolationException(ConstraintViolationException ex) {
+    Map<String, String> errors = new HashMap<>();
+    ex.getConstraintViolations().forEach(violation -> {
+      errors.put("message", violation.getMessage());
+      errors.put("path", (violation.getPropertyPath() != null ? violation.getPropertyPath().toString() : ""));
+    });
+    return new ResponseEntity<>(errors, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<Map<String, String>> handleResourceNotFoundException(ResourceNotFoundException ex, WebRequest request) {
+    return buildResponseEntity(ex.getMessage(), request.getDescription(false), HttpStatus.NOT_FOUND);
+  }
+}

--- a/src/main/java/run/attraction/api/v1/introduction/exception/ResourceNotFoundException.java
+++ b/src/main/java/run/attraction/api/v1/introduction/exception/ResourceNotFoundException.java
@@ -1,0 +1,19 @@
+package run.attraction.api.v1.introduction.exception;
+
+public class ResourceNotFoundException extends RuntimeException {
+  public ResourceNotFoundException() {
+    super();
+  }
+
+  public ResourceNotFoundException(String message) {
+    super(message);
+  }
+
+  public ResourceNotFoundException(String message, Throwable cause) {
+    super(message, cause);
+  }
+
+  public ResourceNotFoundException(Throwable cause) {
+    super(cause);
+  }
+}

--- a/src/main/java/run/attraction/api/v1/introduction/repository/NewsletterRepository.java
+++ b/src/main/java/run/attraction/api/v1/introduction/repository/NewsletterRepository.java
@@ -1,0 +1,7 @@
+package run.attraction.api.v1.introduction.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import run.attraction.api.v1.introduction.Newsletter;
+
+public interface NewsletterRepository extends JpaRepository<Newsletter, Long> {
+}

--- a/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
+++ b/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
@@ -1,0 +1,24 @@
+package run.attraction.api.v1.introduction.service;
+
+import java.util.NoSuchElementException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import run.attraction.api.v1.introduction.Newsletter;
+import run.attraction.api.v1.introduction.dto.response.NewsletterResponse;
+import run.attraction.api.v1.introduction.exception.ErrorMessages;
+import run.attraction.api.v1.introduction.repository.NewsletterRepository;
+
+@Service
+@RequiredArgsConstructor
+public class IntroductionService {
+
+  private final NewsletterRepository newsletterRepository;
+
+  public NewsletterResponse getNewsletter(Long newsletterId) {
+    Newsletter newsletter = newsletterRepository.findById(newsletterId)
+        .orElseThrow(() -> new NoSuchElementException(ErrorMessages.NOT_EXIST_NEWSLETTER.getViewName()));
+    return new NewsletterResponse(newsletter);
+  }
+}
+
+

--- a/src/test/java/run/attraction/api/v1/introduction/controller/IntroductionControllerTest.java
+++ b/src/test/java/run/attraction/api/v1/introduction/controller/IntroductionControllerTest.java
@@ -1,0 +1,103 @@
+package run.attraction.api.v1.introduction.controller;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Collections;
+import java.util.NoSuchElementException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.MockitoAnnotations;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import run.attraction.api.v1.introduction.Category;
+import run.attraction.api.v1.introduction.Newsletter;
+import run.attraction.api.v1.introduction.UploadDays;
+import run.attraction.api.v1.introduction.dto.response.NewsletterResponse;
+import run.attraction.api.v1.introduction.exception.ErrorMessages;
+import run.attraction.api.v1.introduction.service.IntroductionService;
+
+@WebMvcTest(IntroductionController.class)
+class IntroductionControllerTest {
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private IntroductionService introductionService;
+
+  @BeforeEach
+  public void setup() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void getNewsletter_ValidId_ShouldReturnNewsletter() throws Exception {
+    Long newsletterId = 1L;
+    Newsletter newsletter = Newsletter.builder()
+        .name("Technology Trends")
+        .description("Latest updates on technology")
+        .uploadDays(Collections.singletonList(UploadDays.WED))
+        .category(Category.TREND_LIFE)
+        .mainLink("http://www.technewsletter.com")
+        .subscriptionLink("http://www.technewsletter.com/subscribe")
+        .thumbnail("http://www.technewsletter.com/thumbnail.jpg")
+        .build();
+    NewsletterResponse mockResponse = new NewsletterResponse(newsletter);
+    given(introductionService.getNewsletter(newsletterId)).willReturn(mockResponse);
+
+    mockMvc.perform(get("/api/v1/newsletters/{newsletterId}", newsletterId)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.name").value("Technology Trends"))
+        .andExpect(jsonPath("$.description").value("Latest updates on technology"))
+        .andExpect(jsonPath("$.uploadDays").value("WED"))
+        .andExpect(jsonPath("$.category").value("TREND_LIFE"))
+        .andExpect(jsonPath("$.mainLink").value("http://www.technewsletter.com"))
+        .andExpect(jsonPath("$.subscribeLink").value("http://www.technewsletter.com/subscribe"))
+        .andExpect(jsonPath("$.thumbnail").value("http://www.technewsletter.com/thumbnail.jpg"));
+  }
+
+  @Test
+  public void getNewsletter_InvalidId_ShouldReturnBadRequest() throws Exception {
+    mockMvc.perform(get("/api/v1/newsletters/{newsletterId}", -1L)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value("must be greater than or equal to 1"));
+
+    mockMvc.perform(get("/api/v1/newsletters/{newsletterId}", "invalid")
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(ErrorMessages.INVALID_TYPE.getViewName()));
+  }
+
+
+  @Test
+  public void getNewsletter_NonExistingId_ShouldReturnNotFound() throws Exception {
+    Long newsletterId = 99L;
+    doThrow(new NoSuchElementException(ErrorMessages.NOT_EXIST_NEWSLETTER.getViewName())).when(introductionService).getNewsletter(newsletterId);
+
+    mockMvc.perform(get("/api/v1/newsletters/{newsletterId}", newsletterId)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isBadRequest())
+        .andExpect(jsonPath("$.message").value(ErrorMessages.NOT_EXIST_NEWSLETTER.getViewName()));
+  }
+
+  @Test
+  public void getNewsletter_InternalServerError_ShouldReturnInternalServerError() throws Exception {
+    Long newsletterId = 1L;
+    doThrow(new RuntimeException(ErrorMessages.SEVER_ERROR.getViewName())).when(introductionService).getNewsletter(newsletterId);
+
+    mockMvc.perform(get("/api/v1/newsletters/{newsletterId}", newsletterId)
+            .accept(MediaType.APPLICATION_JSON))
+        .andExpect(status().isInternalServerError())
+        .andExpect(jsonPath("$.message").value(ErrorMessages.SEVER_ERROR.getViewName()));
+  }
+
+
+}

--- a/src/test/java/run/attraction/api/v1/introduction/service/IntroductionServiceTest.java
+++ b/src/test/java/run/attraction/api/v1/introduction/service/IntroductionServiceTest.java
@@ -1,0 +1,65 @@
+package run.attraction.api.v1.introduction.service;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import run.attraction.api.v1.introduction.Category;
+import run.attraction.api.v1.introduction.Newsletter;
+import run.attraction.api.v1.introduction.UploadDays;
+import run.attraction.api.v1.introduction.dto.response.NewsletterResponse;
+import run.attraction.api.v1.introduction.repository.NewsletterRepository;
+
+class IntroductionServiceTest {
+  @Mock
+  private NewsletterRepository newsletterRepository;
+
+  @InjectMocks
+  private IntroductionService introductionService;
+
+  @BeforeEach
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+  }
+
+  @Test
+  public void testGetNewsletter_Success() {
+    // given
+    Long newsletterId = 1L;
+    Newsletter newsletter = Newsletter.builder()
+        .id(newsletterId)
+        .name("Tech Weekly")
+        .description("Weekly newsletter about the latest in tech.")
+        .uploadDays(Collections.singletonList(UploadDays.FRI))
+        .category(Category.IT_TECH)
+        .mainLink("http://techweekly.com")
+        .subscriptionLink("http://techweekly.com/subscribe")
+        .thumbnail("http://techweekly.com/thumbnail.jpg")
+        .build();
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.of(newsletter));
+
+    // when
+    NewsletterResponse response = introductionService.getNewsletter(newsletterId);
+
+    // then
+    assertEquals(newsletter.getName(), response.name());
+  }
+
+  @Test
+  public void testGetNewsletter_NotFound() {
+    // given
+    Long newsletterId = 1L;
+    when(newsletterRepository.findById(newsletterId)).thenReturn(Optional.empty());
+
+    // when & then
+    assertThrows(IllegalArgumentException.class, () -> {
+      introductionService.getNewsletter(newsletterId);
+    });
+  }
+}


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- ATR-63

<br/>

## 🔑 Key Changes

- 뉴스레터 get API 구현 
  - 특정 뉴스레터 id를 전달해주면 사전에 정의된 정보를  return 해줌  
- 예외 처리 구현
   - api를 사용하면서 발생할 수 있는 예외 처리 구현
   - IntroductionController 예외
   - Global 예외 

<br/>

## 🤝🏻 To Reviewers

-

<br/>