### PR TITLE
[ATR-170] feat : google refresh token 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,11 @@ dependencies {
     annotationProcessor "com.querydsl:querydsl-apt:5.1.0:jakarta"
     annotationProcessor "jakarta.annotation:jakarta.annotation-api"
     annotationProcessor "jakarta.persistence:jakarta.persistence-api"
+
+    //gmail
+    implementation 'com.google.api-client:google-api-client:2.0.0'
+    implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
+    implementation 'com.google.apis:google-api-services-gmail:v1-rev20220404-2.0.0'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/run/attraction/api/v1/auth/config/AuthProviderConfig.java
+++ b/src/main/java/run/attraction/api/v1/auth/config/AuthProviderConfig.java
@@ -9,16 +9,18 @@ import run.attraction.api.v1.auth.provider.google.GoogleOAuthService;
 import java.util.Arrays;
 import java.util.List;
 import run.attraction.api.v1.auth.provider.oauth.OAuthService;
+import run.attraction.api.v1.auth.token.repository.GoogleRefreshTokenRepository;
 
 @Configuration
 @RequiredArgsConstructor
 public class AuthProviderConfig {
 
   private final GoogleOAuthService googleOAuthService;
+  private final GoogleRefreshTokenRepository googleRefreshTokenRepository;
 
   @Bean
   public AuthProvider authProvider() {
-    return new AuthProvider(getExternalProviders());
+    return new AuthProvider(getExternalProviders(),googleRefreshTokenRepository);
   }
 
   private List<OAuthService> getExternalProviders() {

--- a/src/main/java/run/attraction/api/v1/auth/controller/AuthTestController.java
+++ b/src/main/java/run/attraction/api/v1/auth/controller/AuthTestController.java
@@ -30,11 +30,23 @@ public class AuthTestController {
   @Value("${spring.security.oauth2.client.registration.google.redirect-uri}")
   private String googleRedirectUrl;
 
+  private static final String MAIL_GOOGLE_COM = "https://mail.google.com/";
+  private static final String GMAIL_READONLY = "https://www.googleapis.com/auth/gmail.readonly";
+  private static final String GMAIL_LABELS = "https://www.googleapis.com/auth/gmail.labels";
+  private static final String GMAIL_SETTINGS_BASIC = "https://www.googleapis.com/auth/gmail.settings.basic";
+
   @PostMapping("/api/v1/auth")
   public String loginUrlGoogle() {
     String reqUrl = "https://accounts.google.com/o/oauth2/v2/auth?client_id=" + googleClientId
         + "&redirect_uri=" + googleRedirectUrl
-        + "&response_type=code&scope=email%20profile%20openid&access_type=offline";
+        + "&response_type=code&scope=email profile openid "
+        + MAIL_GOOGLE_COM + " "
+        + GMAIL_READONLY + " "
+        + GMAIL_LABELS + " "
+        + GMAIL_SETTINGS_BASIC + " "
+        + "https://www.googleapis.com/auth/userinfo.email" + " "
+        + "https://www.googleapis.com/auth/userinfo.profile" + " "
+        +"&access_type=offline";
     return reqUrl;
   }
 

--- a/src/main/java/run/attraction/api/v1/auth/provider/AuthProvider.java
+++ b/src/main/java/run/attraction/api/v1/auth/provider/AuthProvider.java
@@ -1,27 +1,58 @@
 package run.attraction.api.v1.auth.provider;
 
 import java.util.List;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import run.attraction.api.v1.auth.provider.oauth.OAuthService;
 import run.attraction.api.v1.auth.provider.oauth.OAuthToken;
+import run.attraction.api.v1.auth.token.GoogleRefreshToken;
+import run.attraction.api.v1.auth.token.repository.GoogleRefreshTokenRepository;
 import run.attraction.api.v1.user.User;
 
 public class AuthProvider {
 
   private static final Logger log = LoggerFactory.getLogger(AuthProvider.class);
   private final List<OAuthService> OAuthServices;
+  private final GoogleRefreshTokenRepository googleRefreshTokenRepository;
 
-  public AuthProvider(List<OAuthService> OAuthServices) {
+  public AuthProvider(List<OAuthService> OAuthServices, GoogleRefreshTokenRepository googleRefreshTokenRepository) {
     this.OAuthServices = OAuthServices;
+    this.googleRefreshTokenRepository = googleRefreshTokenRepository;
   }
 
   public User getUserProfileByCode(String provider, final String code) {
     OAuthService oAuthService = getOAuthService(provider);
     final OAuthToken token = oAuthService.getToken(code);
     final String responseBody = oAuthService.getResponseBody(token.getAccess_token());
-    //
-    return oAuthService.getAuthUser(responseBody);
+    final User authUser = oAuthService.getAuthUser(responseBody);
+
+    String googleRefreshToken = token.getRefresh_token();
+    if (!(googleRefreshToken.isEmpty())) {
+      saveGoogleRefreshToken(googleRefreshToken, authUser.getEmail());
+    }
+    return authUser;
+  }
+
+  private void saveGoogleRefreshToken(String refreshToken, String email) {
+    googleRefreshTokenRepository.findTokenByEmail(email)
+        .ifPresentOrElse(
+            token -> updateGoogleRefreshToken(token, refreshToken),
+            () -> saveNewGoogleRefreshToken(refreshToken, email)
+        );
+  }
+
+  private void saveNewGoogleRefreshToken(String refreshToken, String email) {
+    final GoogleRefreshToken googleRefreshToken = GoogleRefreshToken.builder()
+        .token(refreshToken)
+        .email(email)
+        .build();
+    googleRefreshTokenRepository.save(googleRefreshToken);
+  }
+
+  private void updateGoogleRefreshToken(GoogleRefreshToken googleRefreshToken, String refreshToken) {
+    googleRefreshToken.updateStateAndToken(false, refreshToken);
+    googleRefreshTokenRepository.save(googleRefreshToken);
   }
 
   private OAuthService getOAuthService(String provider) {

--- a/src/main/java/run/attraction/api/v1/auth/provider/AuthProvider.java
+++ b/src/main/java/run/attraction/api/v1/auth/provider/AuthProvider.java
@@ -1,12 +1,15 @@
 package run.attraction.api.v1.auth.provider;
 
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import run.attraction.api.v1.auth.provider.oauth.OAuthService;
 import run.attraction.api.v1.auth.provider.oauth.OAuthToken;
 import run.attraction.api.v1.user.User;
 
 public class AuthProvider {
 
+  private static final Logger log = LoggerFactory.getLogger(AuthProvider.class);
   private final List<OAuthService> OAuthServices;
 
   public AuthProvider(List<OAuthService> OAuthServices) {
@@ -17,6 +20,7 @@ public class AuthProvider {
     OAuthService oAuthService = getOAuthService(provider);
     final OAuthToken token = oAuthService.getToken(code);
     final String responseBody = oAuthService.getResponseBody(token.getAccess_token());
+    //
     return oAuthService.getAuthUser(responseBody);
   }
 

--- a/src/main/java/run/attraction/api/v1/auth/provider/oauth/OAuthToken.java
+++ b/src/main/java/run/attraction/api/v1/auth/provider/oauth/OAuthToken.java
@@ -1,8 +1,10 @@
 package run.attraction.api.v1.auth.provider.oauth;
 
 import lombok.Getter;
+import lombok.ToString;
 
 @Getter
+@ToString
 public class OAuthToken {
   private String access_token;
   private String refresh_token;

--- a/src/main/java/run/attraction/api/v1/auth/token/GoogleRefreshToken.java
+++ b/src/main/java/run/attraction/api/v1/auth/token/GoogleRefreshToken.java
@@ -1,0 +1,43 @@
+package run.attraction.api.v1.auth.token;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@Table(name = "google_refresh_token")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class GoogleRefreshToken {
+
+  @Id
+  @Column(name = "email", length = 100)
+  private String email;
+
+  @Column(name = "refresh_token")
+  private String token;
+
+  @Column(name = "should_reissue_token", nullable = false, columnDefinition = "TINYINT(1) default 0")
+  private boolean shouldReissueToken;
+
+  @Builder
+  private GoogleRefreshToken(String email, String token) {
+    this.email = email;
+    this.token = token;
+  }
+
+  public void updateState(boolean shouldReissueToken){
+    this.shouldReissueToken=shouldReissueToken;
+  }
+
+  public void updateStateAndToken(boolean shouldReissueToken, String token){
+    this.token = token;
+    this.shouldReissueToken=shouldReissueToken;
+  }
+
+}

--- a/src/main/java/run/attraction/api/v1/auth/token/repository/GoogleRefreshTokenRepository.java
+++ b/src/main/java/run/attraction/api/v1/auth/token/repository/GoogleRefreshTokenRepository.java
@@ -1,0 +1,13 @@
+package run.attraction.api.v1.auth.token.repository;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import run.attraction.api.v1.archive.ReadBox;
+import run.attraction.api.v1.auth.token.GoogleRefreshToken;
+
+public interface GoogleRefreshTokenRepository extends JpaRepository<GoogleRefreshToken, String> {
+  @Query("SELECT rt FROM GoogleRefreshToken rt WHERE rt.email = :userEmail AND rt.shouldReissueToken = true")
+  Optional<GoogleRefreshToken> findTokenByEmail(String userEmail);
+}

--- a/src/main/java/run/attraction/api/v1/user/User.java
+++ b/src/main/java/run/attraction/api/v1/user/User.java
@@ -46,8 +46,7 @@ public class User implements UserDetails {
   @Column(name = "update_at")
   private LocalDate updateAt;
 
-  @Column(name = "is_deleted")
-  @ColumnDefault("false")
+  @Column(nullable = false, columnDefinition = "TINYINT(1) default 0")
   private boolean isDeleted;
 
   @Enumerated(EnumType.STRING)
@@ -82,7 +81,6 @@ public class User implements UserDetails {
       String backgroundImg,
       LocalDate createdAt,
       LocalDate updateAt,
-      boolean isDeleted,
       Role role
   ) {
     this.email = email;
@@ -90,7 +88,6 @@ public class User implements UserDetails {
     this.backgroundImg = backgroundImg;
     this.createdAt = createdAt;
     this.updateAt = updateAt;
-    this.isDeleted = isDeleted;
     this.role = role;
   }
 

--- a/src/main/resources/data.sql
+++ b/src/main/resources/data.sql
@@ -100,10 +100,10 @@ INSERT INTO read_box (user_email, article_id, percentage) VALUES
    ("test@gmail.com", 9, 66);
 
 -- User 데이터 삽입
-INSERT  INTO users (email,profile_img,background_img,created_at,update_at,is_deleted,role,nick_Name,birth_date,user_expiration,occupation) VALUES
-    ("user1@gmail.com","profileImgUrl1","backgroundImgUrl1","2024-03-10","2024-05-10",FALSE,"USER","KIM","1998-02-19","2025-11-10","SECURITY"),
-    ("user2@gmail.com","profileImgUrl2","backgroundImgUrl2","2024-04-17","2024-04-29",FALSE,"USER","RYU","1999-05-22","2024-10-17","MARKETING"),
-    ("user3@gmail.com","profileImgUrl3","backgroundImgUrl3","2024-05-01","2024-05-02",FALSE,"USER","KANG","1996-11-18","2025-05-01","PRODUCTION");
+INSERT  INTO users (email,profile_img,background_img,created_at,update_at,role,nick_Name,birth_date,user_expiration,occupation) VALUES
+    ("user1@gmail.com","profileImgUrl1","backgroundImgUrl1","2024-03-10","2024-05-10","USER","KIM","1998-02-19","2025-11-10","SECURITY"),
+    ("user2@gmail.com","profileImgUrl2","backgroundImgUrl2","2024-04-17","2024-04-29","USER","RYU","1999-05-22","2024-10-17","MARKETING"),
+    ("user3@gmail.com","profileImgUrl3","backgroundImgUrl3","2024-05-01","2024-05-02","USER","KANG","1996-11-18","2025-05-01","PRODUCTION");
 
 -- Interest 데이터 삽입
 INSERT INTO interests (email, interests) VALUES


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-170](https://attractorr.atlassian.net/browse/ATR-170?atlOrigin=eyJpIjoiMDZmZDQ0YTgyOGZhNDY5NDg2OWZmYjJjZDc1MzIwZTkiLCJwIjoiaiJ9) : google refresh token 추가

<br/>

## 🔑 Key Changes

- 회원의 Gmail을 확인하기 위해 회원의 google refresh token이 필요
- google refresh token 엔티티 생성
- 구성 : email(String) , token(String), shouldReissueToken(boolean)
- shouldReissueToken는 default가 false이고 Token이 만료되면 true로 변환
- shouldReissueToken는 로그인 과정에서 google API로 부터 받으면 저장

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-170]: https://attractorr.atlassian.net/browse/ATR-170?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ