### PR TITLE
[ATR-260] fix: 정렬이 반대로 되는 오류 수정

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/dto/request/UserArticlesRequest.java
+++ b/src/main/java/run/attraction/api/v1/archive/dto/request/UserArticlesRequest.java
@@ -10,7 +10,7 @@ import lombok.Setter;
 public class UserArticlesRequest {
   private int page = 0;
   private int size = 20;
-  private String[] sort = {"receivedAt", "asc"};
+  private String[] sort = {"receivedAt", "desc"};
   private String isHideRead = "false";
   private String category;
   private String q; // search query

--- a/src/main/java/run/attraction/api/v1/archive/service/ArchiveService.java
+++ b/src/main/java/run/attraction/api/v1/archive/service/ArchiveService.java
@@ -36,12 +36,12 @@ public class ArchiveService {
 
   @Transactional(readOnly = true)
   public Page<ArticleDTO> findArticlesByUserId(String userEmail, UserArticlesRequest request) {
-    String ASC = "asc";
+    String DESC = "desc";
     String HIDE_READ_TRUE = "true";
 
-    String sortDirection = request.getSort().length > 1 ? request.getSort()[1] : ASC;
+    String sortDirection = request.getSort().length > 1 ? request.getSort()[1] : DESC;
     Boolean isHideReadFilter = request.getIsHideRead().equalsIgnoreCase(HIDE_READ_TRUE);
-    Sort sortObj = Sort.by(sortDirection.equalsIgnoreCase(ASC) ? Sort.Order.asc(request.getSort()[0]) : Sort.Order.desc(request.getSort()[0]));
+    Sort sortObj = Sort.by(sortDirection.equalsIgnoreCase(DESC) ? Sort.Order.desc(request.getSort()[0]) : Sort.Order.asc(request.getSort()[0]));
     Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), sortObj);
 
     return articleRepository.findArticlesByUserEmail(userEmail, request.getCategory(), isHideReadFilter, request.getQ(), pageable);


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-260](https://attractorr.atlassian.net/browse/ATR-260?atlOrigin=eyJpIjoiYjY5ZTk1ZjEwYTRlNDlhZThiN2IzZDBkZWMyZTUwYmIiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- [[ATR-260] fix: 최신순 오래된순 정렬이 서로 반대되는 현상 수정](https://github.com/Atractorrr/Attraction-Server/commit/c574dba40f46d80efb560546dc1a0af4fcb6062d)

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-260]: https://attractorr.atlassian.net/browse/ATR-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[ATR-260]: https://attractorr.atlassian.net/browse/ATR-260?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ