### PR TITLE
[ATR-261] fix: readingTime = 0 인 경우도 반영

### DIFF
--- a/src/main/java/run/attraction/api/v1/home/service/dto/article/ArticleDetailDto.java
+++ b/src/main/java/run/attraction/api/v1/home/service/dto/article/ArticleDetailDto.java
@@ -20,8 +20,8 @@ public record ArticleDetailDto(
     Objects.requireNonNull(articleThumbnailUrl);
     Objects.requireNonNull(title);
     Objects.requireNonNull(date);
-    if (readingTime == 0) {
-      throw new IllegalArgumentException("readingTime must be greater than 0");
+    if (readingTime < 0) {
+      throw new IllegalArgumentException("The readingTime value cannot be negative");
     }
     if (readPercentage < 0 || readPercentage > 100) {
       throw new IllegalArgumentException("readingPercentage must be between 0 and 100");


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-261](https://attractorr.atlassian.net/browse/ATR-261?atlOrigin=eyJpIjoiZWYzYWEwODgxNzZiNDFiZWJkOWI5OWMwZTRiZjg3NGIiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- readingTime : 해당 아티클을 읽는데 걸리는 시간
- 수정 전 : readingTime = 0 인 경우를 예외처리 했음
- 수정 후 : readingTime = 0 인 경우는 FE에서 1분미만 이라고 표시할 예정이기 때문에, 0인 경우를 예외처리하며 안됨.
- 변경 사항 : 음수인 경우에만 예외처리함.

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-261]: https://attractorr.atlassian.net/browse/ATR-261?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ