### PR TITLE
[ATR-282] feat: 통계 테이블 생성

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -64,6 +64,9 @@ dependencies {
     implementation 'com.google.api-client:google-api-client:2.0.0'
     implementation 'com.google.oauth-client:google-oauth-client-jetty:1.34.1'
     implementation 'com.google.apis:google-api-services-gmail:v1-rev20220404-2.0.0'
+
+    //test
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.withType(JavaCompile).configureEach {

--- a/src/main/java/run/attraction/api/v1/statistics/AgeGroup.java
+++ b/src/main/java/run/attraction/api/v1/statistics/AgeGroup.java
@@ -1,0 +1,41 @@
+package run.attraction.api.v1.statistics;
+
+import java.time.LocalDate;
+import java.time.MonthDay;
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum AgeGroup {
+  TEENAGER("10대", 10),
+  TWENTIES("20대", 20),
+  THIRTIES("30대", 30),
+  FORTIES("40대", 40),
+  FIFTIES("50대", 50),
+  SIXTIES("60대", 60),
+  SEVENTIES("70대", 70),
+  EIGHTIES("80대", 80);
+
+  private final String viewName;
+  private final int ageGroup;
+
+  public static AgeGroup calculateAge(LocalDate date) {
+    int age = LocalDate.now().getYear() - date.getYear();
+
+    final MonthDay birthDate = MonthDay.of(date.getMonth(), date.getDayOfMonth());
+    final MonthDay now = MonthDay.now();
+
+    if (birthDate.isBefore(now)) {
+      age--;
+    }
+
+    int ageGroup = (age / 10) * 10;
+
+    return Arrays.stream(AgeGroup.values())
+        .filter(group -> group.getAgeGroup() == ageGroup)
+        .findFirst()
+        .orElseThrow();  //예외를 던져야 하나 고민중...
+  }
+}

--- a/src/main/java/run/attraction/api/v1/statistics/NewsletterEvent.java
+++ b/src/main/java/run/attraction/api/v1/statistics/NewsletterEvent.java
@@ -1,0 +1,48 @@
+package run.attraction.api.v1.statistics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import run.attraction.api.v1.archive.AuditableEntity;
+import run.attraction.api.v1.user.Occupation;
+
+@Getter
+@Entity
+@Table(name = "statistics_newsletter_event")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class NewsletterEvent extends AuditableEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "newsletter_id", nullable = false)
+  private Long newsletterId;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Occupation occupation;
+
+  @Column(name = "age_group",nullable = false)
+  @Enumerated(EnumType.STRING)
+  private AgeGroup ageGroup;
+
+  @Builder
+  private NewsletterEvent(Long newsletterId, Occupation occupation, AgeGroup ageGroup) {
+    this.newsletterId = newsletterId;
+    this.occupation = occupation;
+    this.ageGroup = ageGroup;
+  }
+}

--- a/src/main/java/run/attraction/api/v1/statistics/repository/NewsletterEventRepository.java
+++ b/src/main/java/run/attraction/api/v1/statistics/repository/NewsletterEventRepository.java
@@ -1,0 +1,12 @@
+package run.attraction.api.v1.statistics.repository;
+
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import run.attraction.api.v1.statistics.AgeGroup;
+import run.attraction.api.v1.statistics.NewsletterEvent;
+import run.attraction.api.v1.user.Occupation;
+
+public interface NewsletterEventRepository extends JpaRepository<NewsletterEvent,Long> {
+  List<NewsletterEvent> findByOccupation(Occupation occupation);
+  List<NewsletterEvent> findByAgeGroup(AgeGroup ageGroup);
+}

--- a/src/test/java/run/attraction/api/v1/statistics/AgeGroupTest.java
+++ b/src/test/java/run/attraction/api/v1/statistics/AgeGroupTest.java
@@ -1,0 +1,19 @@
+package run.attraction.api.v1.statistics;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class AgeGroupTest {
+  @Test
+  @DisplayName("calculateAge 테스트")
+  void calculateAgeTest() {
+    //when
+    LocalDate birthDate = LocalDate.now().minusYears(32);
+    //given
+    //then
+    assertEquals(AgeGroup.calculateAge(birthDate),AgeGroup.THIRTIES);
+  }
+}

--- a/src/test/java/run/attraction/api/v1/statistics/NewsletterEventRepositoryTest.java
+++ b/src/test/java/run/attraction/api/v1/statistics/NewsletterEventRepositoryTest.java
@@ -1,0 +1,80 @@
+package run.attraction.api.v1.statistics;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.TestPropertySource;
+import run.attraction.api.v1.introduction.repository.NewsletterRepository;
+import run.attraction.api.v1.statistics.repository.NewsletterEventRepository;
+import run.attraction.api.v1.user.Occupation;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@TestPropertySource("classpath:application-test.yml")
+public class NewsletterEventRepositoryTest {
+
+  @Autowired
+  private NewsletterEventRepository repository;
+
+  @Value("${spring.datasource.url}")
+  private String datasourceUrl;
+  @Autowired
+  private NewsletterRepository newsletterRepository;
+
+  @BeforeEach
+  void setUp(){
+    NewsletterEvent event1 = NewsletterEvent.builder()
+        .newsletterId(1L)
+        .occupation(Occupation.STUDENT)
+        .ageGroup(AgeGroup.TWENTIES)
+        .build();
+
+    NewsletterEvent event2 = NewsletterEvent.builder()
+        .newsletterId(2L)
+        .occupation(Occupation.STUDENT)
+        .ageGroup(AgeGroup.TWENTIES)
+        .build();
+
+    NewsletterEvent event3 = NewsletterEvent.builder()
+        .newsletterId(3L)
+        .occupation(Occupation.SELFEMPLOY)
+        .ageGroup(AgeGroup.FORTIES)
+        .build();
+
+    repository.saveAll(List.of(event1,event2,event3));
+  }
+
+  @Test
+  @DisplayName("Occupation 탐색 테스트")
+  void findByOccupationTest(){
+    // given
+    String string = "STUDENT";
+    // when
+    List<NewsletterEvent> events = repository.findByOccupation(Occupation.valueOf(string));
+
+    // then
+    assertEquals(events.size(),2);
+
+  }
+
+  @Test
+  @DisplayName("AgeGroup 탐색 테스트")
+  void findByAgeGroupTest(){
+    // given
+    final AgeGroup ageGroup = AgeGroup.TWENTIES;
+    // when
+    List<NewsletterEvent> events = repository.findByAgeGroup(ageGroup);
+
+    // then
+    assertEquals(events.size(),2);
+  }
+
+}
+

--- a/src/test/resources/data-h2.sql
+++ b/src/test/resources/data-h2.sql
@@ -1,0 +1,56 @@
+-- 테이블이 이미 존재하는 경우 삭제
+DROP TABLE IF EXISTS newsletter_ids;
+DROP TABLE IF EXISTS subscribe;
+DROP TABLE IF EXISTS interests;
+DROP TABLE IF EXISTS newsletter;
+
+CREATE TABLE newsletter_ids (
+    subscribe_id BIGINT,
+    newsletter_id BIGINT,
+    PRIMARY KEY (subscribe_id, newsletter_id)
+);
+
+
+CREATE TABLE interests (
+   email VARCHAR(255) NOT NULL,
+   interests VARCHAR(255) NOT NULL,
+   PRIMARY KEY (email, interests)
+);
+
+CREATE TABLE IF NOT EXISTS newsletter (
+  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+  category VARCHAR(255),
+    created_at TIMESTAMP,
+    description VARCHAR(255),
+    email VARCHAR(255),
+    is_deleted BOOLEAN,
+    main_link VARCHAR(255),
+    modified_at TIMESTAMP,
+    name VARCHAR(255),
+    nickname VARCHAR(255),
+    subscribe_link VARCHAR(255),
+    thumbnail_url VARCHAR(255),
+    upload_days VARCHAR(255)
+);
+
+INSERT INTO `interests` (email, interests) VALUES
+   ('test1@gmail.com', 'LIVING_INTERIOR'),
+   ('test1@gmail.com', 'FOOD'),
+   ('test1@gmail.com', 'LOCAL_TRAVEL'),
+   ('test1@gmail.com', 'HOBBY_SELF_DEVELOPMENT'),
+   ('test2@gmail.com', 'LIVING_INTERIOR'),
+   ('test2@gmail.com', 'IT_TECH'),
+   ('test2@gmail.com', 'BUSINESS_FINANCIAL_TECHNOLOGY'),
+   ('test2@gmail.com', 'CURRENT_AFFAIRS_SOCIETY'),
+   ('test3@gmail.com', 'DESIGN'),
+   ('test3@gmail.com', 'TREND_LIFE'),
+   ('test3@gmail.com', 'LOCAL_TRAVEL');
+
+INSERT INTO `newsletter_ids` (subscribe_id, newsletter_id) VALUES
+   (2, 6),
+   (2, 18),
+   (2, 44),
+   (2, 50),
+   (2, 62),
+   (3, 28),
+   (3, 31);


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-282](https://attractorr.atlassian.net/browse/ATR-282?atlOrigin=eyJpIjoiY2JiMWYwNDIxNzI4NDEwNzhhNDQxYTU4YjkxZTY0YmEiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- `AgeGroup` 
  -  테이블에서 사용자의 연령대를 표시하는 객체 
- `NewsletterEvent ` 
  - 사용자가 아티클을 다 읽었을때, 해당 아티클의 뉴스레터 정볼르 저장
  - 저장할때, 사용자의 연령대와 직업을 같이 저장

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-282]: https://attractorr.atlassian.net/browse/ATR-282?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ