### PR TITLE
Feature/atr 298 occupation statistics

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/repository/ReadBoxRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ReadBoxRepository.java
@@ -20,8 +20,8 @@ public interface ReadBoxRepository extends JpaRepository<ReadBox, Long> {
     SELECT rb.userEmail, COUNT(rb)
     FROM ReadBox rb 
     WHERE rb.readDate BETWEEN :startDate AND :endDate
-    AND rb.readDate <> :excludeDate
-    AND rb.readPercentage = 100 
+     AND rb.readDate <> :excludeDate
+     AND rb.readPercentage = 100 
     GROUP BY rb.userEmail
     ORDER BY COUNT(rb) DESC
   """)

--- a/src/main/java/run/attraction/api/v1/rank/service/RankCalculator.java
+++ b/src/main/java/run/attraction/api/v1/rank/service/RankCalculator.java
@@ -23,12 +23,12 @@ public class RankCalculator {
   }
 
   private List<ExtensiveRank> calculateExtensiveRank(LocalDate date) {
-    log.info("저장된 데이터가 존재하지 않아, 새로 계산합니다.")
+    log.info("저장된 데이터가 존재하지 않아, 새로 계산합니다.");
     LocalDate[] dateRange = getDateRange(date);
 
     LocalDate startDate = dateRange[0];
     LocalDate endDate = dateRange[1];
-    log.info("조회 범위")
+    log.info("조회 범위");
     log.info("startDate: {}, endDate: {}", startDate, endDate);
 
     final List<Object[]> top10Emails = readBoxRepository.findTop10ExtensiveUsers(startDate,endDate,date);

--- a/src/main/java/run/attraction/api/v1/statistics/OccupationStatistics.java
+++ b/src/main/java/run/attraction/api/v1/statistics/OccupationStatistics.java
@@ -1,0 +1,45 @@
+package run.attraction.api.v1.statistics;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDate;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import run.attraction.api.v1.user.Occupation;
+
+
+@Getter
+@Entity
+@Table(name = "occupation_statistics")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class OccupationStatistics {
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private Long newsletterId;
+
+  @Column(nullable = false)
+  @Enumerated(EnumType.STRING)
+  private Occupation occupation;
+
+  @Column(name = "created_at",nullable = false)
+  private LocalDate createdAt;
+
+  @Builder
+  private OccupationStatistics(Long newsletterId,Occupation occupation, LocalDate createdAt) {
+    this.newsletterId = newsletterId;
+    this.occupation = occupation;
+    this.createdAt = createdAt;
+  }
+
+}

--- a/src/main/java/run/attraction/api/v1/statistics/controller/StatisticsController.java
+++ b/src/main/java/run/attraction/api/v1/statistics/controller/StatisticsController.java
@@ -1,0 +1,22 @@
+package run.attraction.api.v1.statistics.controller;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import run.attraction.api.v1.statistics.service.StatisticsService;
+
+@RestController
+@RequestMapping("/api/v1/statistics")
+@RequiredArgsConstructor
+public class StatisticsController {
+  private final StatisticsService statisticsService;
+
+  @GetMapping("/occupation")
+  public ResponseEntity<?> makeOccupationStatistics(){
+    statisticsService.makeOccupationStatistics(LocalDate.now());
+    return ResponseEntity.ok().build();
+  }
+}

--- a/src/main/java/run/attraction/api/v1/statistics/repository/NewsletterEventRepository.java
+++ b/src/main/java/run/attraction/api/v1/statistics/repository/NewsletterEventRepository.java
@@ -1,7 +1,9 @@
 package run.attraction.api.v1.statistics.repository;
 
 import java.util.List;
+import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import run.attraction.api.v1.statistics.AgeGroup;
 import run.attraction.api.v1.statistics.NewsletterEvent;
 import run.attraction.api.v1.user.Occupation;
@@ -9,4 +11,15 @@ import run.attraction.api.v1.user.Occupation;
 public interface NewsletterEventRepository extends JpaRepository<NewsletterEvent,Long> {
   List<NewsletterEvent> findByOccupation(Occupation occupation);
   List<NewsletterEvent> findByAgeGroup(AgeGroup ageGroup);
+
+  @Query(value = """
+          SELECT occupation, newsletter_id 
+          FROM (SELECT occupation, newsletter_id, 
+                       ROW_NUMBER() OVER (PARTITION BY occupation ORDER BY COUNT(newsletter_id) DESC) as rn 
+                FROM statistics_newsletter_event
+                WHERE created_at < :endDate
+                GROUP BY occupation, newsletter_id) subquery 
+          WHERE rn = 1
+       """,nativeQuery = true)
+  List<Object[]> findMostPopularNewsletterOccupationPairs(LocalDateTime endDate);
 }

--- a/src/main/java/run/attraction/api/v1/statistics/repository/OccupationStatisticsRepository.java
+++ b/src/main/java/run/attraction/api/v1/statistics/repository/OccupationStatisticsRepository.java
@@ -1,0 +1,10 @@
+package run.attraction.api.v1.statistics.repository;
+
+import java.time.LocalDate;
+import java.util.List;
+import org.springframework.data.repository.CrudRepository;
+import run.attraction.api.v1.statistics.OccupationStatistics;
+
+public interface OccupationStatisticsRepository extends CrudRepository<OccupationStatistics, Long> {
+  List<OccupationStatistics> findAllByCreatedAt(LocalDate createdAt);
+}

--- a/src/main/java/run/attraction/api/v1/statistics/service/StatisticsService.java
+++ b/src/main/java/run/attraction/api/v1/statistics/service/StatisticsService.java
@@ -1,0 +1,17 @@
+package run.attraction.api.v1.statistics.service;
+
+import java.time.LocalDate;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import run.attraction.api.v1.statistics.service.occupation.OccupationStatisticsCalculator;
+
+@Service
+@RequiredArgsConstructor
+public class StatisticsService {
+  private final OccupationStatisticsCalculator occupationStatisticsCalculator;
+
+  public void makeOccupationStatistics(LocalDate date){
+    occupationStatisticsCalculator.getOccupationStatistics(date);
+  }
+
+}

--- a/src/main/java/run/attraction/api/v1/statistics/service/occupation/OccupationStatisticsCalculator.java
+++ b/src/main/java/run/attraction/api/v1/statistics/service/occupation/OccupationStatisticsCalculator.java
@@ -1,0 +1,39 @@
+package run.attraction.api.v1.statistics.service.occupation;
+
+import java.time.LocalDate;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import run.attraction.api.v1.statistics.OccupationStatistics;
+import run.attraction.api.v1.statistics.repository.NewsletterEventRepository;
+import run.attraction.api.v1.statistics.repository.OccupationStatisticsRepository;
+import run.attraction.api.v1.user.Occupation;
+
+@Component
+@RequiredArgsConstructor
+public class OccupationStatisticsCalculator {
+  private final NewsletterEventRepository newsletterEventRepository;
+  private final OccupationStatisticsRepository occupationStatisticsRepository;
+
+  public List<OccupationStatistics> getOccupationStatistics(LocalDate date){
+    final List<OccupationStatistics> statistics = occupationStatisticsRepository.findAllByCreatedAt(date.minusDays(1));
+    return statistics.isEmpty() ? calculateOccupationStatistics(date) : statistics;
+  }
+
+  public List<OccupationStatistics> calculateOccupationStatistics(LocalDate date) {
+    List<Object[]> newsletterOccupationPairs = newsletterEventRepository.findMostPopularNewsletterOccupationPairs(date.atStartOfDay());
+
+    List<OccupationStatistics> statistics = newsletterOccupationPairs.stream()
+        .map(obj -> OccupationStatistics.builder()
+            .occupation(Occupation.valueOf((String)obj[0]))
+            .newsletterId((Long)obj[1])
+            .createdAt(date.minusDays(1))
+            .build()
+    ).toList();
+
+    occupationStatisticsRepository.saveAll(statistics);
+
+    return statistics;
+  }
+
+}


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-298](https://attractorr.atlassian.net/browse/ATR-298?atlOrigin=eyJpIjoiYTA2MzE2ZTAwNmUxNDU3ZWI2N2M4NjE0MzFhOGVjYTEiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- `OccupationStatistics`
  - NewsletterEvent에서 조회한 "직업별 인기 있는 뉴스레터"를 저장하는 테이블
  - 매일 업데이트 ( 조회범위는 전체 )
- `OccupationStatisticsCalculator`
  - NewsletterEventRepository의 데이터로 조회
  - 직업별로 가장 인기 있는 뉴스레터를 하나씩 계산

<br/>

## 🤝🏻 To Reviewers


<br/>


[ATR-298]: https://attractorr.atlassian.net/browse/ATR-298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ