### PR TITLE
[ATR-412] feat: NewsletterEvent 저장 로직 추가

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
@@ -59,4 +59,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     """)
   Page<ArticleSearchDto> findArticleBySearch(String search, Pageable pageable);
 
+  @Query("""
+    SELECT n.id 
+    FROM Article a
+    JOIN Newsletter n ON a.newsletterEmail = n.email
+    WHERE a.id = :articleId
+    """)
+  Long findNewsletterIdByArticleId(Long articleId);
 }

--- a/src/main/java/run/attraction/api/v1/statistics/repository/NewsletterEventRepository.java
+++ b/src/main/java/run/attraction/api/v1/statistics/repository/NewsletterEventRepository.java
@@ -1,12 +1,13 @@
 package run.attraction.api.v1.statistics.repository;
 
-import java.util.List;
-import java.time.LocalDateTime;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import run.attraction.api.v1.statistics.AgeGroup;
 import run.attraction.api.v1.statistics.NewsletterEvent;
 import run.attraction.api.v1.user.Occupation;
+
+import java.time.LocalDateTime;
+import java.util.List;
 
 public interface NewsletterEventRepository extends JpaRepository<NewsletterEvent,Long> {
   List<NewsletterEvent> findByOccupation(Occupation occupation);


### PR DESCRIPTION
## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-412](https://attractorr.atlassian.net/browse/ATR-412?atlOrigin=eyJpIjoiNTAyMDY2ZmVmY2NlNGMzYjhjNzQzYmYxODY0ZjU4MjciLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- ReadBox=100 인 경우 NewsletterEvent 저장
- 해당 아티클의 뉴스레터 id와 사용자의 적업군 연령대 저장


<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-412]: https://attractorr.atlassian.net/browse/ATR-412?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ