### PR TITLE
[ATR-441] feat: findArticleByUserEmailAndArticleId 메서드 수정

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryImpl.java
@@ -107,9 +107,9 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom{
     return Optional.ofNullable(queryFactory
         .select(new QArticleDTO(this.article, readBox.readPercentage, newsletter))
         .from(this.article)
-        .join(readBox).on(this.article.id.eq(readBox.articleId).and(this.article.userEmail.eq(readBox.userEmail)))
+        .join(readBox).on(this.article.id.eq(readBox.articleId).and(readBox.userEmail.eq(userEmail)))
         .join(newsletter).on(this.article.newsletterEmail.eq(newsletter.email))
-        .where(article.id.eq(articleId).and(article.userEmail.eq(userEmail)))
+        .where(article.id.eq(articleId))
         .fetchOne());
   }
 


### PR DESCRIPTION
- article.userEmail이 분변력이 없어졌기에 제거
- readBox.userEmail과 파라미터로 받은 userEmail로 join

## ⚙️ PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-441](https://attractorr.atlassian.net/browse/ATR-441?atlOrigin=eyJpIjoiZDljNmJiMDRhNGZlNDg4N2E2NzEzMDhiNzMwYWZmMTEiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

-

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-441]: https://attractorr.atlassian.net/browse/ATR-441?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ