### PR TITLE
[ATR-487] feat: 뉴스레터 엔티티에 동의 필드 추가 (#220)

### DIFF
--- a/src/main/java/run/attraction/api/v1/introduction/Newsletter.java
+++ b/src/main/java/run/attraction/api/v1/introduction/Newsletter.java
@@ -58,6 +58,14 @@ public class Newsletter extends AuditableEntity {
   @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
   private boolean hasConfirmationEmail = false;
 
+  @Default
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT TRUE")
+  private boolean isAgreePersonalInfoCollection = true;
+
+  @Default
+  @Column(nullable = false, columnDefinition = "BOOLEAN DEFAULT FALSE")
+  private boolean isAgreeAdInfoReception = false;
+
   private String nickname;
 
   @Default

--- a/src/main/java/run/attraction/api/v1/introduction/dto/response/NewsletterResponse.java
+++ b/src/main/java/run/attraction/api/v1/introduction/dto/response/NewsletterResponse.java
@@ -11,7 +11,10 @@ public record NewsletterResponse(
     String mainLink,
     String subscribeLink,
     String thumbnailUrl,
-    boolean isAutoSubscribeEnabled
+    boolean isAutoSubscribeEnabled,
+    boolean isAgreePersonalInfoCollection,
+    boolean isAgreeAdInfoReception
+
 ) {
   public static NewsletterResponse from(Newsletter newsletter) {
     return new NewsletterResponse(
@@ -22,7 +25,9 @@ public record NewsletterResponse(
         newsletter.getMainLink(),
         newsletter.getSubscribeLink(),
         newsletter.getThumbnailUrl(),
-        newsletter.isAutoSubscribeEnabled()
+        newsletter.isAutoSubscribeEnabled(),
+        newsletter.isAgreePersonalInfoCollection(),
+        newsletter.isAgreeAdInfoReception()
     );
   }
 }


### PR DESCRIPTION
[[ATR-487] feat: 뉴스레터 엔티티에 동의 필드 추가 ](https://github.com/Atractorrr/Attraction-Server/commit/6e123fe334903e7fdc8ff69c67d54e8c47df279e)


[ATR-487]: https://attractorr.atlassian.net/browse/ATR-487?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ