### PR TITLE
[ATR-502] fix: 아티클 보관함 및 최근 받은 아티클 에러 수정

### DIFF
--- a/src/main/java/run/attraction/api/v1/home/service/article/HomeArticleServiceImpl.java
+++ b/src/main/java/run/attraction/api/v1/home/service/article/HomeArticleServiceImpl.java
@@ -1,12 +1,11 @@
 package run.attraction.api.v1.home.service.article;
 
-import java.util.ArrayList;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
-import run.attraction.api.v1.introduction.Subscribe;
 import run.attraction.api.v1.archive.repository.ArticleRepository;
 import run.attraction.api.v1.introduction.repository.SubscribeRepository;
 import run.attraction.api.v1.home.service.dto.article.ReceivedArticlesDto;
@@ -14,6 +13,7 @@ import run.attraction.api.v1.home.service.dto.search.ArticleSearchDto;
 
 import java.util.List;
 import run.attraction.api.v1.introduction.repository.NewsletterRepository;
+import run.attraction.api.v1.introduction.utils.SubscriptionUtil;
 
 @Component
 @RequiredArgsConstructor
@@ -21,19 +21,14 @@ public class HomeArticleServiceImpl implements HomeArticleService {
   private final ArticleRepository articleRepository;
   private final SubscribeRepository subscribeRepository;
   private final NewsletterRepository newsletterRepository;
+  private final SubscriptionUtil subscriptionUtil;
 
   public List<ReceivedArticlesDto> getReceivedArticles(String userEmail, int size){
-    Subscribe subscribe = subscribeRepository.findByUserEmail(userEmail)
-        .orElse(null);
+    List<String> newsletterEmails = subscriptionUtil.getNewsletterEmailsSubscribedByUser(userEmail, subscribeRepository, newsletterRepository);
 
-    if(subscribe == null) {
-      return new ArrayList<>();
+    if(newsletterEmails.isEmpty()) {
+      return Collections.emptyList();
     }
-
-    List<String> newsletterEmails = subscribe.getNewsletterIds()
-        .stream()
-        .map(id -> newsletterRepository.findById(id).get().getEmail())
-        .toList();
 
     return articleRepository.findReceivedArticlesByUserEmail(userEmail, newsletterEmails, size);
   }

--- a/src/main/java/run/attraction/api/v1/introduction/utils/SubscriptionUtil.java
+++ b/src/main/java/run/attraction/api/v1/introduction/utils/SubscriptionUtil.java
@@ -1,0 +1,23 @@
+package run.attraction.api.v1.introduction.utils;
+
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+import run.attraction.api.v1.introduction.repository.NewsletterRepository;
+import run.attraction.api.v1.introduction.repository.SubscribeRepository;
+
+@Component
+public class SubscriptionUtil {
+
+  public List<String> getNewsletterEmailsSubscribedByUser(String userEmail, SubscribeRepository subscribeRepository,
+                                                       NewsletterRepository newsletterRepository) {
+    return subscribeRepository.findByUserEmail(userEmail)
+        .map(subscription -> subscription.getNewsletterIds()
+            .stream()
+            .map(newsletterRepository::findById)
+            .filter(Optional::isPresent)
+            .map(newsletter -> newsletter.get().getEmail())
+            .toList())
+        .orElseGet(List::of);
+  }
+}


### PR DESCRIPTION
- 존재하지 않는 뉴스레터 id가 구독함에 들어있는 경우 고려
- 기존 로직은 고려하고 있지 않아서 에러 발생으로 아예 메서드 중단

## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-502](https://attractorr.atlassian.net/browse/ATR-502?atlOrigin=eyJpIjoiNTMwZjQ3MmRiNDZkNDcxM2JkNjZlNzk5NjNjM2JlOTMiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- 기존 로직은 존재 하지 않는 뉴스레터 id가 구독함에 들어있는 상황을 고려하고 있지 않아서 에러 발생으로 아예 메서드 중단
수정 -->  존재하지 않는 뉴스레터 id가 구독함에 들어있는 경우 고려

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-502]: https://attractorr.atlassian.net/browse/ATR-502?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ