### PR TITLE
[ATR-503] feat: 자동 구독이 가능할 때만 카프카메시지 전송해서 동작하도록 수정 (#228)

### DIFF
--- a/src/main/java/run/attraction/api/v1/introduction/service/SubscriptionService.java
+++ b/src/main/java/run/attraction/api/v1/introduction/service/SubscriptionService.java
@@ -89,11 +89,13 @@ public class SubscriptionService {
   }
 
   public void sendKafkaMessageForSubscription(String userEmail, Newsletter newsletter) {
-    String nickname = userDetailRepository.findNicknameByEmail(userEmail)
-        .orElseThrow(() -> new IllegalArgumentException("회원정보에 없는 유저입니다"));
+    if(newsletter.isAutoSubscribeEnabled()) {
+      String nickname = userDetailRepository.findNicknameByEmail(userEmail)
+          .orElseThrow(() -> new IllegalArgumentException("회원정보에 없는 유저입니다"));
 
-    log.info("카프카 메시지 전송 시작");
-    kafkaProducerService.sendKafkaMessage(userEmail, nickname, newsletter.getSubscribeLink(), true, false);
-    log.info("카프카 메시지 전송 종료");
+      log.info("카프카 메시지 전송 시작");
+      kafkaProducerService.sendKafkaMessage(userEmail, nickname, newsletter.getSubscribeLink(), true, false);
+      log.info("카프카 메시지 전송 종료");
+    }
   }
 }


### PR DESCRIPTION
[[ATR-503] feat: 자동 구독이 가능할 때만 카프카메시지 전송해서 동작하도록 수정 ](https://github.com/Atractorrr/Attraction-Server/commit/77decee05f75fe878f014784bc301b7445b05d21)


[ATR-503]: https://attractorr.atlassian.net/browse/ATR-503?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ