### PR TITLE
[ATR-534] hotfix: 최근 받은 아티클 로직 쿼리 추가

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryImpl.java
@@ -165,6 +165,7 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
             .and(Expressions.dateTemplate(LocalDate.class, "DATE({0})", readBox.modifiedAt)
                 .between(sixDaysAgo, currentDate))
             .and(newsletter.id.eq(subscription.newsletterId)))
+        .where(article.receivedAt.between(sixDaysAgo, currentDate))
         .orderBy(readBox.modifiedAt.desc())
         .limit(size);
 


### PR DESCRIPTION
- 최근 받은 아티클중에 아티클을 받은지 7일 이내만 보여주도록 설정 추가
- .where(article.receivedAt.between(sixDaysAgo, currentDate)) 추가

## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-534](https://attractorr.atlassian.net/browse/ATR-534?atlOrigin=eyJpIjoiN2JjYWJkY2MxNjkzNDgxMTk0NzFlMjMzYjNiZjhiOWMiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- 최근 받은 아티클중에 아티클을 받은지 7일 이내만 보여주도록 설정 추가
 - .where(article.receivedAt.between(sixDaysAgo, currentDate)) 추가

<br/>

## 🤝🏻 why?

현재 받은지 7일 넘어가는 아티클도 보임

```java
.where(readBox.modifiedAt.isNotNull()
            .and(Expressions.dateTemplate(LocalDate.class, "DATE({0})", readBox.modifiedAt)
                .between(sixDaysAgo, currentDate))
```
해당 로직으로는  읽은 것을 또 읽으면 modifiedAt이 업데이트 되기 때문에 7일이내 계속 아티클을 본다면 데이터가 아예 삭제될 때 까지 읽은 아티클에서 볼 수 있음

<br/>


[ATR-534]: https://attractorr.atlassian.net/browse/ATR-534?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ