### PR TITLE
[ATR-541] fix: 지난 아티클중 일부가 정상적으로 정렬되지 않는 현상을 수정

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
@@ -31,5 +31,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     """)
   Long findNewsletterIdByArticleId(Long articleId);
 
+  @Query("""
+    SELECT a
+    FROM Article a
+    JOIN Newsletter n ON a.newsletterEmail = n.email
+    WHERE a.newsletterEmail = :newsletterEmail
+    ORDER BY a.receivedAt DESC
+  """)
   List<Article> findArticlesByNewsletterEmail(String newsletterEmail);
 }

--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
@@ -31,12 +31,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     """)
   Long findNewsletterIdByArticleId(Long articleId);
 
-  @Query("""
-    SELECT a
-    FROM Article a
-    JOIN Newsletter n ON a.newsletterEmail = n.email
-    WHERE a.newsletterEmail = :newsletterEmail
-    ORDER BY a.receivedAt DESC
-  """)
-  List<Article> findArticlesByNewsletterEmail(String newsletterEmail);
+  @Query(value = "SELECT a "
+      + "FROM Article a "
+      + "JOIN Newsletter n ON a.newsletterEmail = n.email "
+      + "WHERE a.newsletterEmail = :newsletterEmail "
+      + "ORDER BY a.receivedAt DESC "
+      + "LIMIT :size", nativeQuery = true)
+  List<Article> findArticlesByNewsletterEmail(String newsletterEmail, int size);
 }

--- a/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
+++ b/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
@@ -36,12 +36,11 @@ public class IntroductionService {
   public List<PreviousArticleResponse> getPreviousArticles(Long newsletterId, int size) {
     Newsletter newsletter = newsletterRepository.findById(newsletterId)
         .orElseThrow(() -> new NoSuchElementException(ErrorMessages.NOT_EXIST_NEWSLETTER.getViewName()));
-    List<Article> previousArticles = articleRepository.findArticlesByNewsletterEmail(newsletter.getEmail());
+    List<Article> previousArticles = articleRepository.findArticlesByNewsletterEmail(newsletter.getEmail(), size);
 
     return previousArticles.stream()
-        .limit(size)
         .map(previousArticle -> PreviousArticleResponse.from(previousArticle, newsletter.getName()))
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-541](https://attractorr.atlassian.net/browse/ATR-541?atlOrigin=eyJpIjoiOGMxYThjNzE5ODUzNGQ3YTljZDEwOTc1Nzg4ZGFhN2QiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- 지난 아티클중 일부가 정상적으로 정렬되지 않는 현상 수정
   - DESC 정렬
- [refactor: limit를 서비스단에서 레포에서 사용하도록 변경](https://github.com/Atractorrr/Attraction-Server/pull/253/commits/815591f89f4e3b944108e8dec03886ad5b8e526c)

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-541]: https://attractorr.atlassian.net/browse/ATR-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ