### PR TITLE
[ATR-541] fix: 지난 아티클중 일부가 정상적으로 정렬되지 않는 현상을 수정

### DIFF
--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
@@ -31,5 +31,12 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     """)
   Long findNewsletterIdByArticleId(Long articleId);
 
+  @Query("""
+    SELECT a
+    FROM Article a
+    JOIN Newsletter n ON a.newsletterEmail = n.email
+    WHERE a.newsletterEmail = :newsletterEmail
+    ORDER BY a.receivedAt DESC
+  """)
   List<Article> findArticlesByNewsletterEmail(String newsletterEmail);
 }

--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
@@ -30,12 +30,4 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     WHERE a.id = :articleId
     """)
   Long findNewsletterIdByArticleId(Long articleId);
-
-  @Query(value = "SELECT a "
-      + "FROM Article a "
-      + "JOIN Newsletter n ON a.newsletterEmail = n.email "
-      + "WHERE a.newsletterEmail = :newsletterEmail "
-      + "ORDER BY a.receivedAt DESC "
-      + "LIMIT :size", nativeQuery = true)
-  List<Article> findArticlesByNewsletterEmail(String newsletterEmail, int size);
 }

--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepository.java
@@ -31,12 +31,11 @@ public interface ArticleRepository extends JpaRepository<Article, Long>, Article
     """)
   Long findNewsletterIdByArticleId(Long articleId);
 
-  @Query("""
-    SELECT a
-    FROM Article a
-    JOIN Newsletter n ON a.newsletterEmail = n.email
-    WHERE a.newsletterEmail = :newsletterEmail
-    ORDER BY a.receivedAt DESC
-  """)
-  List<Article> findArticlesByNewsletterEmail(String newsletterEmail);
+  @Query(value = "SELECT a "
+      + "FROM Article a "
+      + "JOIN Newsletter n ON a.newsletterEmail = n.email "
+      + "WHERE a.newsletterEmail = :newsletterEmail "
+      + "ORDER BY a.receivedAt DESC "
+      + "LIMIT :size", nativeQuery = true)
+  List<Article> findArticlesByNewsletterEmail(String newsletterEmail, int size);
 }

--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryCustom.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryCustom.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import run.attraction.api.v1.archive.dto.ArticleDTO;
 import run.attraction.api.v1.home.service.dto.article.ReceivedArticlesDto;
+import run.attraction.api.v1.introduction.dto.response.PreviousArticleResponse;
 import run.attraction.api.v1.mypage.service.dto.archive.article.RecentArticlesDto;
 
 public interface ArticleRepositoryCustom {
@@ -15,4 +16,5 @@ public interface ArticleRepositoryCustom {
   Optional<ArticleDTO> findArticleByUserEmailAndArticleId(String userEmail, Long articleId);
   List<RecentArticlesDto> findRecentArticlesByUserEmail(String userEmail, int size);
   List<ReceivedArticlesDto> findReceivedArticlesByUserEmail(String userEmail, List<String> newsletterEmails,  int size);
+  List<PreviousArticleResponse> findPreviousArticlesByUserEmail(String userEmail, int size);
 }

--- a/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryImpl.java
+++ b/src/main/java/run/attraction/api/v1/archive/repository/ArticleRepositoryImpl.java
@@ -21,6 +21,8 @@ import run.attraction.api.v1.home.service.dto.article.ReceivedArticlesDto;
 import run.attraction.api.v1.introduction.Category;
 import run.attraction.api.v1.introduction.QNewsletter;
 import run.attraction.api.v1.introduction.QSubscription;
+import run.attraction.api.v1.introduction.dto.response.PreviousArticleResponse;
+import run.attraction.api.v1.introduction.dto.response.QPreviousArticleResponse;
 import run.attraction.api.v1.mypage.service.dto.archive.article.QRecentArticlesDto;
 import run.attraction.api.v1.mypage.service.dto.archive.article.RecentArticlesDto;
 
@@ -185,4 +187,16 @@ public class ArticleRepositoryImpl implements ArticleRepositoryCustom {
 
     return articles.fetch();
   }
+
+  public List<PreviousArticleResponse> findPreviousArticlesByUserEmail(String userEmail, int size) {
+    return queryFactory
+        .select(new QPreviousArticleResponse(this.article, newsletter))
+        .from(this.article)
+        .join(newsletter).on(newsletter.email.eq(userEmail))
+        .where(this.article.newsletterEmail.eq(newsletter.email))
+        .orderBy(this.article.receivedAt.desc())
+        .limit(size)
+        .fetch();
+  }
+
 }

--- a/src/main/java/run/attraction/api/v1/archive/service/ArchiveService.java
+++ b/src/main/java/run/attraction/api/v1/archive/service/ArchiveService.java
@@ -46,7 +46,6 @@ public class ArchiveService {
   final private ReadBoxRepository readBoxRepository;
   final private NewsletterRepository newsletterRepository;
   final private SubscriptionRepository subscriptionRepository;
-  final private UserSubscribedNewsletterCategoryRepository userSubscribedNewsletterCategoryRepository;
   private final UserDetailRepository userDetailRepository;
   private final NewsletterEventRepository newsletterEventRepository;
   private final ReadBoxEventRepository readBoxEventRepository;

--- a/src/main/java/run/attraction/api/v1/introduction/dto/response/PreviousArticleResponse.java
+++ b/src/main/java/run/attraction/api/v1/introduction/dto/response/PreviousArticleResponse.java
@@ -1,6 +1,7 @@
 package run.attraction.api.v1.introduction.dto.response;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.querydsl.core.annotations.QueryProjection;
 import run.attraction.api.v1.archive.Article;
 import run.attraction.api.v1.archive.dto.NewsletterDTO;
 import run.attraction.api.v1.introduction.Newsletter;
@@ -20,6 +21,21 @@ public record PreviousArticleResponse(
     NewsletterDTO newsletter
 ) {
 
+  @QueryProjection
+  public PreviousArticleResponse(Article article, Newsletter newsletter) {
+    this(
+         article.getId(),
+        article.getTitle(),
+        article.getThumbnailUrl(),
+        article.getContentUrl(),
+        article.getContentSummary(),
+        article.getReadingTime() ,
+        article.getReceivedAt(),
+        newsletter.getName(),
+        new NewsletterDTO(newsletter)
+    );
+  }
+
   public static PreviousArticleResponse from(Article article, String newsletterName) {
     return new PreviousArticleResponse(
         article.getId(),
@@ -33,7 +49,6 @@ public record PreviousArticleResponse(
         null
     );
   }
-
   public static PreviousArticleResponse from(Article article, Newsletter newsletter) {
     return new PreviousArticleResponse(
         article.getId(),

--- a/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
+++ b/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
@@ -36,12 +36,11 @@ public class IntroductionService {
   public List<PreviousArticleResponse> getPreviousArticles(Long newsletterId, int size) {
     Newsletter newsletter = newsletterRepository.findById(newsletterId)
         .orElseThrow(() -> new NoSuchElementException(ErrorMessages.NOT_EXIST_NEWSLETTER.getViewName()));
-    List<Article> previousArticles = articleRepository.findArticlesByNewsletterEmail(newsletter.getEmail());
+    List<Article> previousArticles = articleRepository.findArticlesByNewsletterEmail(newsletter.getEmail(), size);
 
     return previousArticles.stream()
-        .limit(size)
         .map(previousArticle -> PreviousArticleResponse.from(previousArticle, newsletter.getName()))
-        .collect(Collectors.toList());
+        .toList();
   }
 
   @Transactional(readOnly = true)

--- a/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
+++ b/src/main/java/run/attraction/api/v1/introduction/service/IntroductionService.java
@@ -36,11 +36,8 @@ public class IntroductionService {
   public List<PreviousArticleResponse> getPreviousArticles(Long newsletterId, int size) {
     Newsletter newsletter = newsletterRepository.findById(newsletterId)
         .orElseThrow(() -> new NoSuchElementException(ErrorMessages.NOT_EXIST_NEWSLETTER.getViewName()));
-    List<Article> previousArticles = articleRepository.findArticlesByNewsletterEmail(newsletter.getEmail(), size);
 
-    return previousArticles.stream()
-        .map(previousArticle -> PreviousArticleResponse.from(previousArticle, newsletter.getName()))
-        .toList();
+    return articleRepository.findPreviousArticlesByUserEmail(newsletter.getEmail(), size);
   }
 
   @Transactional(readOnly = true)


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-541](https://attractorr.atlassian.net/browse/ATR-541?atlOrigin=eyJpIjoiM2IyODg2ZDhhMWJkNDAwYjg2M2Q1OTkxYzhkZWVkNzciLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- 일부 아티클이 정렬되지 않는 현상 수정
  - 전체 DESC 정렬
- querydsl로 변경
  - 레포지토리에서 바로 엔티티로 반환
<br/>

## 🤝🏻 why?

- 지난 아티클에 order이 적용되어있지 않았음
- 추가 했으나 잘못된 쿼리로 에러
- queryDSL로 수정
  -  pageable을 굳이 사용할 필요없이 바로 limit 사용과 db에서 필요한 데이터만 뽑기위해

<br/>



[ATR-541]: https://attractorr.atlassian.net/browse/ATR-541?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ