### PR TITLE
[ATR-548] fix: 도커 타임존 서울로 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,7 +86,7 @@ jobs:
             docker run -d --name redis-server -p 6379:6379 redis:latest
             
             # Spring Boot 애플리케이션 컨테이너 실행
-            docker run -d --name attraction-api-server --link redis-server:redis -p 8080:8080 -v /home/ec2-user/workspace/logs:/logs ${{ steps.ecr-login.outputs.registry }}/attraction-api-server:latest
+            docker run -d --name attraction-api-server --link redis-server:redis -e TZ=Asia/Seoul -p 8080:8080 -v /home/ec2-user/workspace/logs:/logs ${{ steps.ecr-login.outputs.registry }}/attraction-api-server:latest
             
              # filebeat 실행
             docker stop filebeat || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,15 @@
 FROM eclipse-temurin:21-jdk-alpine
+
+# 필요한 패키지 설치 (tzdata)
+RUN apk add --no-cache tzdata
+
+# 시간대 설정
+ENV TZ=Asia/Seoul
+RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
+
+# 애플리케이션 JAR 파일 추가
 COPY ./build/libs/*SNAPSHOT.jar project.jar
+
+# 애플리케이션 실행
 ENTRYPOINT ["java", "-jar", "project.jar"]
 


### PR DESCRIPTION
## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-548](https://attractorr.atlassian.net/browse/ATR-548?atlOrigin=eyJpIjoiYjBkYWNjNWIzOWU3NGNkYWJkMDY2OGZiNzJjYzJlNDMiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- 도커 타임존 서울로 설정

<br/>

## 🤝🏻 why

현재 서버는 로컬타임이 서울로 설정 되어있지만 도커 내부는  UTC로 설정되어있음

<br/>


[ATR-548]: https://attractorr.atlassian.net/browse/ATR-548?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ