### PR TITLE
[ATR-599] fix: 구독한 뉴스레터를 가져올 때 구독취소한 것도 가져오는 현상 수정

### DIFF
--- a/src/main/java/run/attraction/api/v1/introduction/service/SubscriptionService.java
+++ b/src/main/java/run/attraction/api/v1/introduction/service/SubscriptionService.java
@@ -100,10 +100,7 @@ public class SubscriptionService {
   }
 
   public List<SubscribedNewsletterResponse> getUserSubscribedNewsletters(String userEmail) {
-    List<Long> subscribedNewslettersByUser = subscriptionRepository.findByUserEmail(userEmail)
-        .stream()
-        .map(Subscription::getNewsletterId)
-        .toList();
+    List<Long> subscribedNewslettersByUser = subscriptionRepository.findNewsletterIdsByUserEmailWithoutIsDeleted(userEmail);
     List<Newsletter> newsletters = newsletterRepository.findAllById(subscribedNewslettersByUser);
 
     return newsletters


### PR DESCRIPTION
- 구독은 취소한 뉴스레터는 가져오지 않도록 수정

## ⚙️ PR Type

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<br/>

## 📑 Related JIRA Epic(Issue)

- [ATR-599](https://attractorr.atlassian.net/browse/ATR-599?atlOrigin=eyJpIjoiOGQyNDIzNjk2OTYyNGE5NTk2NWU3MDU2NGU0YzFlM2MiLCJwIjoiaiJ9)

<br/>

## 🔑 Key Changes

- 구독 취소한 뉴스레터는 가져오지 않도록 수정

<br/>

## 🤝🏻 To Reviewers

-

<br/>


[ATR-599]: https://attractorr.atlassian.net/browse/ATR-599?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ